### PR TITLE
Fix custom-actions.module.js for browserify

### DIFF
--- a/js/custom-actions.module.js
+++ b/js/custom-actions.module.js
@@ -1,4 +1,4 @@
-angular.module('customActions').component('customAction', {
+angular.module('customActions', []).component('customAction', {
   bindings: {
     name: '@',
     label: '@',


### PR DESCRIPTION
I seems that removing `angular.module('customActions', []);` causes troubles.  angular.module needs second parameter to create new module.